### PR TITLE
feat(design-system): add disabled state support across components

### DIFF
--- a/packages/design-system/src/components/EditableInfoCard/EditableInfoCard.stories.tsx
+++ b/packages/design-system/src/components/EditableInfoCard/EditableInfoCard.stories.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
-import { EditableInfoCard, EditableInfoCardProps } from './EditableInfoCard';
 import { Meta, StoryFn } from '@storybook/react';
-import { useModal } from '../../hooks/useModal/useModal';
 import { format } from 'date-fns';
-import { SelectOption } from '../SelectButtons/SelectButtons';
-import { Text } from 'react-native-paper';
-import { IconButton } from 'react-native-paper';
+import React, { useState } from 'react';
 import { View } from 'react-native';
+import { IconButton, Text } from 'react-native-paper';
+import { useModal } from '../../hooks/useModal/useModal';
+import { SelectOption } from '../SelectButtons/SelectButtons';
+import { EditableInfoCard, EditableInfoCardProps } from './EditableInfoCard';
 
 const ItemViewMeta: Meta<EditableInfoCardProps> = {
   component: EditableInfoCard,
@@ -462,3 +461,37 @@ export const SaveInProgress: StoryFn<EditableInfoCardProps> = (args) => {
     />
   );
 };
+
+export const Disabled: StoryFn<EditableInfoCardProps> = (args) => {
+  const [value, setValue] = useState('This card is disabled');
+  return (
+    <EditableInfoCard
+      {...args}
+      label="Disabled Card"
+      value={value}
+      editable={true}
+      inlineEditable={true}
+      disabled={true}
+      onInlineEdit={(newValue) => setValue(newValue as string)}
+    />
+  );
+};
+
+export const DisabledWithCustomAction: StoryFn<EditableInfoCardProps> = (
+  args
+) => (
+  <EditableInfoCard
+    {...args}
+    label="Disabled with Custom Action"
+    value="Disabled card with custom action"
+    disabled={true}
+    rightAction={
+      <IconButton
+        icon="star"
+        size={20}
+        onPress={() => console.log('Star pressed')}
+        disabled={true}
+      />
+    }
+  />
+);

--- a/packages/design-system/src/components/EditableInfoCard/EditableInfoCard.tsx
+++ b/packages/design-system/src/components/EditableInfoCard/EditableInfoCard.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  NativeSyntheticEvent,
+  Platform,
   Pressable,
   StyleProp,
   StyleSheet,
+  TextInputKeyPressEventData,
   TextStyle,
   View,
   ViewStyle,
-  Platform,
 } from 'react-native';
 import { ActivityIndicator, IconButton, Text } from 'react-native-paper';
 import { AppTheme } from '../../hooks/_useAppThemeSetup';
 import { useTheme } from '../../providers/ThemeProvider';
 import { TextInput } from '../TextInput/TextInput';
-import { NativeSyntheticEvent } from 'react-native';
-import { TextInputKeyPressEventData } from 'react-native';
 
 export interface EditableInfoCardProps {
   label?: string;
@@ -23,6 +23,7 @@ export interface EditableInfoCardProps {
   renderValue?: (value?: unknown) => React.ReactNode;
   editable?: boolean; // determine if the item is editable
   inlineEditable?: boolean; // if the item is inline editable
+  disabled?: boolean; // Add disabled prop
   onEdit?: () => void; // Callback function when edit icon is pressed
   onInlineEdit?: (newValue?: unknown) => void; // Callback function when inline edit is pressed
   labelStyle?: StyleProp<TextStyle>;
@@ -106,6 +107,7 @@ export function EditableInfoCard({
   processing,
   editable,
   inlineEditable,
+  disabled = false,
   onEdit,
   onInlineEdit,
   renderValue,
@@ -132,6 +134,8 @@ export function EditableInfoCard({
   }, [value]);
 
   const handleEdit = () => {
+    if (disabled) return;
+
     if (inlineEditable) {
       setIsEditing(true);
     } else if (editable && onEdit) {
@@ -140,6 +144,8 @@ export function EditableInfoCard({
   };
 
   const handleInlineEditComplete = () => {
+    if (disabled) return;
+
     if (validate) {
       const validationResult = validate(editedValue);
       if (typeof validationResult === 'string') {
@@ -182,7 +188,7 @@ export function EditableInfoCard({
               style={styles.icon}
               onPress={handleInlineEditComplete}
               accessibilityLabel="Confirm edit"
-              disabled={isSaving}
+              disabled={isSaving || disabled}
             />
             {isSaving ? (
               <ActivityIndicator size={20} style={styles.icon} />
@@ -193,6 +199,7 @@ export function EditableInfoCard({
                 style={styles.icon}
                 onPress={handleInlineEditCancel}
                 accessibilityLabel="Cancel editing"
+                disabled={disabled}
               />
             )}
           </>
@@ -203,6 +210,7 @@ export function EditableInfoCard({
             style={styles.icon}
             onPress={handleEdit}
             accessibilityLabel="Edit value"
+            disabled={disabled}
           />
         )}
       </>
@@ -269,7 +277,15 @@ export function EditableInfoCard({
   return (
     <Pressable
       onPress={handlePress}
-      disabled={!editable && !inlineEditable && !onRightActionPress}
+      disabled={
+        (!editable && !inlineEditable && !onRightActionPress) || disabled
+      }
+      style={({ pressed }) => [
+        styles.container,
+        containerStyle,
+        disabled && { opacity: 0.5 },
+        pressed && !disabled && { opacity: 0.7 },
+      ]}
     >
       {content}
     </Pressable>

--- a/packages/design-system/src/components/LabelSwitch/LabelSwitch.stories.tsx
+++ b/packages/design-system/src/components/LabelSwitch/LabelSwitch.stories.tsx
@@ -100,10 +100,8 @@ export const WithCustomStyles: StoryObj<LabelSwitchProps> = {
 export const Disabled: StoryObj<LabelSwitchProps> = {
   args: {
     value: true,
+    disabled: true,
     onValueChange: () => {},
-    containerStyle: {
-      opacity: 0.5,
-    },
     icon: <MaterialIcons name="block" size={24} color="#999" />,
     label: 'Disabled Switch',
   },
@@ -114,8 +112,8 @@ export const Disabled: StoryObj<LabelSwitchProps> = {
 <LabelSwitch 
   label="Disabled Switch" 
   value={true} 
+  disabled={true}
   onValueChange={() => {}} 
-  containerStyle={{ opacity: 0.5 }}
   icon={<MaterialIcons name="block" size={24} color="#999" />}
 />`,
       },

--- a/packages/design-system/src/components/LabelSwitch/LabelSwitch.tsx
+++ b/packages/design-system/src/components/LabelSwitch/LabelSwitch.tsx
@@ -35,6 +35,7 @@ export interface LabelSwitchProps {
   labelStyle?: StyleProp<TextStyle>;
   onValueChange: (value: boolean) => void;
   icon?: React.ReactNode;
+  disabled?: boolean;
 }
 
 export const LabelSwitch = ({
@@ -44,18 +45,22 @@ export const LabelSwitch = ({
   labelStyle,
   onValueChange,
   icon,
+  disabled = false,
 }: LabelSwitchProps) => {
   const theme = useTheme();
   const styles = useMemo(() => getStyle(theme), [theme]);
 
   const handleContainerPress = () => {
-    onValueChange(!value);
+    if (!disabled) {
+      onValueChange(!value);
+    }
   };
 
   return (
     <Pressable
-      style={[styles.container, containerStyle]}
+      style={[styles.container, containerStyle, disabled && { opacity: 0.5 }]}
       onPress={handleContainerPress}
+      disabled={disabled}
     >
       <View style={styles.labelContainer}>
         {icon && <View style={styles.icon}>{icon}</View>}
@@ -64,7 +69,7 @@ export const LabelSwitch = ({
       <Switch
         value={value}
         onValueChange={onValueChange}
-        // Prevent the Pressable's onPress from firing when the Switch is pressed
+        disabled={disabled}
         onTouchStart={(e) => e.stopPropagation()}
       />
     </Pressable>

--- a/packages/design-system/src/components/NumberAdjuster/NumberAdjuster.stories.tsx
+++ b/packages/design-system/src/components/NumberAdjuster/NumberAdjuster.stories.tsx
@@ -30,10 +30,15 @@ const NumberAdjusterMeta: Meta<NumberAdjusterProps> = {
       action: 'changed',
       description: 'Callback function when the value changes',
     },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the number adjuster is disabled',
+    },
   },
   args: {
     label: 'Number Adjuster',
     value: 10,
+    disabled: false,
   },
 };
 
@@ -60,6 +65,34 @@ export const MinMaxSet = (args: NumberAdjusterProps) => {
       onChange={setValue}
       min={5}
       max={50}
+    />
+  );
+};
+
+export const Disabled = (args: NumberAdjusterProps) => {
+  const [value, setValue] = useState(args.value);
+  return (
+    <NumberAdjuster
+      {...args}
+      value={value}
+      onChange={setValue}
+      disabled={true}
+    />
+  );
+};
+
+export const DisabledWithCustomValue = (args: NumberAdjusterProps) => {
+  const [value, setValue] = useState(42);
+  return (
+    <NumberAdjuster
+      {...args}
+      label="Disabled Number Adjuster"
+      value={value}
+      onChange={setValue}
+      disabled={true}
+      min={0}
+      max={100}
+      step={5}
     />
   );
 };

--- a/packages/design-system/src/components/NumberAdjuster/NumberAdjuster.tsx
+++ b/packages/design-system/src/components/NumberAdjuster/NumberAdjuster.tsx
@@ -28,6 +28,7 @@ export interface NumberAdjusterProps {
   min?: number;
   max?: number;
   step?: number;
+  disabled?: boolean;
   containerStyle?: StyleProp<ViewStyle>;
   inputStyle?: StyleProp<ViewStyle>;
   buttonStyle?: StyleProp<ViewStyle>;
@@ -42,6 +43,7 @@ export const NumberAdjuster: React.FC<NumberAdjusterProps> = ({
   min = 1,
   max = Infinity,
   step = 1,
+  disabled = false,
   containerStyle,
   inputStyle,
   buttonStyle,
@@ -52,22 +54,26 @@ export const NumberAdjuster: React.FC<NumberAdjusterProps> = ({
   const [localValue, setLocalValue] = useState(value.toString());
 
   const handleIncrement = () => {
+    if (disabled) return;
     const newValue = Math.min(value + step, max);
     onChange(newValue);
     setLocalValue(newValue.toString());
   };
 
   const handleDecrement = () => {
+    if (disabled) return;
     const newValue = Math.max(value - step, min);
     onChange(newValue);
     setLocalValue(newValue.toString());
   };
 
   const handleChangeText = (text: string) => {
+    if (disabled) return;
     setLocalValue(text);
   };
 
   const handleFinishEditing = () => {
+    if (disabled) return;
     const newValue = parseInt(localValue, 10);
     if (!isNaN(newValue)) {
       const boundedValue = Math.max(Math.min(newValue, max), min);
@@ -79,7 +85,9 @@ export const NumberAdjuster: React.FC<NumberAdjusterProps> = ({
   };
 
   return (
-    <View style={[styles.inputRow, containerStyle]}>
+    <View
+      style={[styles.inputRow, containerStyle, disabled && { opacity: 0.5 }]}
+    >
       <TextInput
         label={label}
         value={localValue}
@@ -89,13 +97,22 @@ export const NumberAdjuster: React.FC<NumberAdjusterProps> = ({
         onSubmitEditing={handleFinishEditing}
         keyboardType="numeric"
         returnKeyType="done"
+        editable={!disabled}
         {...textInputProps}
       />
       <View style={[styles.buttonContainer, buttonContainerStyle]}>
-        <Button onPress={handleDecrement} style={[buttonStyle]}>
+        <Button
+          onPress={handleDecrement}
+          style={[buttonStyle]}
+          disabled={disabled}
+        >
           -{step}
         </Button>
-        <Button onPress={handleIncrement} style={[buttonStyle]}>
+        <Button
+          onPress={handleIncrement}
+          style={[buttonStyle]}
+          disabled={disabled}
+        >
           +{step}
         </Button>
       </View>

--- a/packages/design-system/src/components/Text/Text.stories.tsx
+++ b/packages/design-system/src/components/Text/Text.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Text } from './Text';
+
+const TextMeta: Meta<typeof Text> = {
+  component: Text,
+  tags: ['autodocs'],
+  args: {
+    children: 'Hello world',
+  },
+};
+
+export default TextMeta;
+type Story = StoryObj<typeof Text>;
+
+export const Basic: Story = {
+  name: 'Default Text',
+  parameters: {
+    docs: {
+      source: {
+        code: `
+import { Text } from '@siteed/design-system';
+<Text>Hello world</Text>
+        `,
+      },
+    },
+  },
+};
+
+export const Variant: Story = {
+  name: 'Heading Text',
+  args: {
+    variant: 'headlineMedium',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+import { Text } from '@siteed/design-system';
+<Text variant="headlineMedium">Hello world</Text>
+        `,
+      },
+    },
+  },
+};

--- a/packages/design-system/src/components/Text/Text.tsx
+++ b/packages/design-system/src/components/Text/Text.tsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import { Text as PaperText, TextProps } from 'react-native-paper';
+
+export const Text = (props: TextProps<string>) => <PaperText {...props} />;

--- a/packages/design-system/src/components/picker/picker.stories.tsx
+++ b/packages/design-system/src/components/picker/picker.stories.tsx
@@ -289,3 +289,32 @@ export const CustomPressBehavior: StoryObj<PickerProps> = {
     },
   },
 };
+
+export const Disabled: StoryObj<PickerProps> = {
+  args: {
+    ...CategoryPickerMeta.args,
+    disabled: true,
+    options: options.map((opt, index) => ({
+      ...opt,
+      color: colorOptions[index % colorOptions.length]?.value,
+    })),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This variant shows the Picker component in a disabled state, preventing any user interaction.',
+      },
+      source: {
+        code: `
+<Picker 
+  label="Category" 
+  options={options} 
+  multi={true}
+  disabled={true}
+/>
+        `,
+      },
+    },
+  },
+};

--- a/packages/design-system/src/components/picker/picker.tsx
+++ b/packages/design-system/src/components/picker/picker.tsx
@@ -50,6 +50,7 @@ export interface PickerProps {
   enableDynamicSizing?: boolean;
   showSearch?: boolean;
   fullWidthOptions?: boolean;
+  disabled?: boolean;
   onFinish?: (selection: SelectOption[]) => void;
   onItemPress?: (item: SelectOption) => void;
   emptyAction?: () => void;
@@ -66,6 +67,7 @@ export const Picker = ({
   multi = false,
   showSearch = false,
   fullWidthOptions = false,
+  disabled = false,
   emptyLabel = 'No options available',
   emptyOptionsTitle = 'No options available',
   emptyOptionsMessage = 'No options available',
@@ -86,6 +88,8 @@ export const Picker = ({
   }, [initialOptions]);
 
   const handlePick = useCallback(async () => {
+    if (disabled) return;
+
     try {
       const result = await openDrawer<SelectOption[]>({
         title: label,
@@ -135,6 +139,7 @@ export const Picker = ({
       logger.error('Error opening picker', error);
     }
   }, [
+    disabled,
     openDrawer,
     label,
     activeOptions,
@@ -151,8 +156,8 @@ export const Picker = ({
   );
 
   return (
-    <View style={styles.container}>
-      <Pressable style={styles.header} onPress={handlePick}>
+    <View style={[styles.container, disabled && { opacity: 0.5 }]}>
+      <Pressable style={styles.header} onPress={handlePick} disabled={disabled}>
         <Text style={styles.title} variant="headlineMedium">
           {label}
         </Text>

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -37,6 +37,7 @@ export * from './components/Slider/Slider';
 export * from './components/HelperWrapper/HelperWrapper';
 export * from './components/HelperText/HelperText';
 export * from './components/DarkLightToggle/DarkLightToggle';
+export * from './components/Text/Text';
 // Settings related components, useful to re-use and visualize in external storybooks
 export * from './settings/ThemeConfig/ThemeConfig';
 export * from './settings/ThemeViewer/ThemeViewer';


### PR DESCRIPTION
# Description
This PR enhances several design system components by adding consistent disabled state support, introducing a new Text wrapper component, and improving overall component accessibility.

## Key Changes

### Added Disabled State Support
- Added `disabled` prop to multiple components:
  - EditableInfoCard
  - LabelSwitch 
  - NumberAdjuster
  - Picker
- Implemented consistent disabled state styling (opacity: 0.5)
- Added new stories demonstrating disabled states for each component

### New Components
- Introduced Text wrapper component around react-native-paper's Text for consistent text handling
- Added corresponding stories and documentation for the Text component

### Component-specific Improvements
1. EditableInfoCard:
   - Added disabled state handling for all interactive elements
   - Updated styles to reflect disabled state
   - Added new stories showcasing disabled variants

2. LabelSwitch:
   - Refactored disabled state implementation from style-based to prop-based
   - Improved accessibility by properly disabling all interactive elements

3. NumberAdjuster:
   - Added disabled state for input and adjustment buttons
   - Improved state handling in increment/decrement functions

4. Picker:
   - Added disabled state support with visual feedback
   - Updated event handlers to respect disabled state

## Testing Instructions
1. Verify disabled state appearance and behavior:
   ```jsx
   <EditableInfoCard disabled={true} />
   <LabelSwitch disabled={true} />
   <NumberAdjuster disabled={true} />
   <Picker disabled={true} />
   ```
2. Test interaction blocking in disabled state
3. Verify accessibility features work correctly with screen readers
4. Check that the new Text component maintains proper styling across different variants

## Breaking Changes
None. All new features are opt-in and backward compatible.

