### PR TITLE
fix(design-system): prevent modal content recreation on parent re-renders in openDrawer

### DIFF
--- a/examples/designdemo/package.json
+++ b/examples/designdemo/package.json
@@ -73,12 +73,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },
-  "resolutions": {
-    "@siteed/react-native-logger": "0.8.2",
-    "react-native-gesture-handler": "~2.24.0",
-    "@gorhom/bottom-sheet": "^4.6.0",
-    "react-native-reanimated": "~3.17.4"
-  },
   "nohoist": [
     "**/@siteed/react-native-logger",
     "**/@siteed/react-native-logger/**"

--- a/examples/designdemo/src/app/(tabs)/bug.tsx
+++ b/examples/designdemo/src/app/(tabs)/bug.tsx
@@ -6,13 +6,27 @@ import {
   useModal,
   useThemePreferences,
 } from "@siteed/design-system/src";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
-import { Button, Text } from "react-native-paper";
+import { Button, Text, TextInput } from "react-native-paper";
 
 const getStyles = () => {
   return StyleSheet.create({
-    container: {},
+    container: {
+      padding: 20,
+    },
+    parentStateBox: {
+      backgroundColor: "#f0f0f0",
+      padding: 10,
+      marginVertical: 10,
+      borderRadius: 5,
+    },
+    modalStateBox: {
+      backgroundColor: "#e0f0e0",
+      padding: 10,
+      marginVertical: 10,
+      borderRadius: 5,
+    },
   });
 };
 
@@ -27,19 +41,51 @@ export const Bug = () => {
 
   const { openDrawer } = useModal();
   const [viewType, setViewType] = useState<"view" | "scroll">("view");
+  const [parentRenderCount, setParentRenderCount] = useState(0);
+  const [parentInput, setParentInput] = useState("");
+  const parentRenderRef = useRef(0);
+
+  // Track parent renders
+  useEffect(() => {
+    parentRenderRef.current += 1;
+    console.log(
+      `[PARENT] Component rendered: ${parentRenderRef.current} times`,
+    );
+  });
+
+  // Update the display count separately to avoid infinite loop
+  useEffect(() => {
+    setParentRenderCount(parentRenderRef.current);
+  }, [parentInput, viewType]); // Only update when these change
 
   return (
     <View style={styles.container}>
       <ThemeConfig colors={colors} />
+
+      <View style={styles.parentStateBox}>
+        <Text variant="titleMedium">Parent Component State</Text>
+        <Text>Parent render count: {parentRenderCount}</Text>
+        <TextInput
+          label="Type here to trigger parent re-renders"
+          value={parentInput}
+          onChangeText={setParentInput}
+          mode="outlined"
+          style={{ marginTop: 10 }}
+        />
+      </View>
+
       <Button
         onPress={() => {
           setViewType(viewType === "view" ? "scroll" : "view");
         }}
       >
-        {viewType}
+        Toggle View Type: {viewType}
       </Button>
+
       <Button
+        mode="contained"
         onPress={() => {
+          console.log("[PARENT] Opening drawer...");
           openDrawer({
             footerType: "confirm_cancel",
             containerType: viewType === "view" ? "view" : "scrollview",
@@ -48,12 +94,17 @@ export const Bug = () => {
               // snapPoints: [],
               // backdropComponent: undefined,
             },
-            render: ({ onChange, state }) => (
-              <InnerComponent
-                onChange={onChange}
-                footerHeight={state.footerHeight}
-              />
-            ),
+            render: ({ onChange, state, resolve }) => {
+              console.log("[DRAWER] Render function called");
+              return (
+                <InnerComponent
+                  onChange={onChange}
+                  footerHeight={state.footerHeight}
+                  parentRenderCount={parentRenderCount}
+                  resolve={resolve}
+                />
+              );
+            },
             renderFooter: ({ state }) => (
               <View style={{ backgroundColor: "green", padding: 20 }}>
                 <Text>FOOTER here</Text>
@@ -63,9 +114,11 @@ export const Bug = () => {
             ),
           });
         }}
+        style={{ marginTop: 10 }}
       >
-        drawer
+        Open Drawer (Check Console)
       </Button>
+
       <Button
         onPress={() => {
           openDrawer({
@@ -83,6 +136,7 @@ export const Bug = () => {
             ),
           });
         }}
+        style={{ marginTop: 10 }}
       >
         Test Long Scroll
       </Button>
@@ -93,29 +147,109 @@ export const Bug = () => {
 interface InnerComponentProps {
   onChange?: (value: unknown) => void;
   footerHeight?: number;
+  parentRenderCount?: number;
+  resolve?: (value: unknown) => void;
 }
-const InnerComponent = ({ onChange, footerHeight }: InnerComponentProps) => {
+
+const InnerComponent = ({
+  onChange,
+  footerHeight,
+  parentRenderCount,
+  resolve,
+}: InnerComponentProps) => {
   const { theme } = useThemePreferences();
   const [date, setDate] = useState(new Date());
   const { editProp } = useModal();
   const [title, setTitle] = useState("Title");
+  const [modalInput, setModalInput] = useState("");
+  const [modalRenderCount, setModalRenderCount] = useState(0);
+  const modalRenderRef = useRef(0);
+  const mountTimeRef = useRef(Date.now());
   const [options, setOptions] = useState<SelectOption[]>([
     { label: "Option 1", value: "1" },
     { label: "Option 2", value: "2" },
     { label: "Option 3", value: "3" },
   ]);
+
+  // Track modal renders
+  useEffect(() => {
+    modalRenderRef.current += 1;
+    console.log(
+      `[MODAL] InnerComponent rendered: ${modalRenderRef.current} times`,
+    );
+  });
+
+  // Update the display count separately to avoid infinite loop
+  useEffect(() => {
+    setModalRenderCount(modalRenderRef.current);
+  }, [modalInput, title, date]); // Only update when these change
+
+  // Track mount/unmount
+  useEffect(() => {
+    const mountTime = Date.now();
+    console.log(`[MODAL] InnerComponent MOUNTED at ${mountTime}`);
+
+    return () => {
+      console.log(
+        `[MODAL] InnerComponent UNMOUNTED after ${Date.now() - mountTime}ms`,
+      );
+    };
+  }, []);
+
   return (
     <View>
+      <View
+        style={{
+          backgroundColor: "#e0f0e0",
+          padding: 10,
+          marginBottom: 10,
+          borderRadius: 5,
+        }}
+      >
+        <Text variant="titleMedium">Modal Component State</Text>
+        <Text>Modal render count: {modalRenderCount}</Text>
+        <Text>Parent render count when opened: {parentRenderCount}</Text>
+        <Text>
+          Component age:{" "}
+          {Math.floor((Date.now() - mountTimeRef.current) / 1000)}s
+        </Text>
+      </View>
+
+      <TextInput
+        label="Type here - should NOT recreate modal"
+        value={modalInput}
+        onChangeText={(text) => {
+          console.log(`[MODAL] Input changed to: "${text}"`);
+          setModalInput(text);
+          onChange?.({ modalInput: text });
+        }}
+        mode="outlined"
+        style={{ marginBottom: 10 }}
+      />
+
       <Text>Inner Component</Text>
       <Text>footerHeight: {footerHeight}</Text>
+
       <Button
         onPress={() => {
-          console.log("onPress", onChange);
+          console.log("[MODAL] Change button pressed");
           onChange?.("test");
         }}
       >
-        Change
+        Change Data
       </Button>
+
+      <Button
+        mode="outlined"
+        onPress={() => {
+          console.log("[MODAL] Closing modal with data");
+          resolve?.({ modalInput, title, date });
+        }}
+        style={{ marginTop: 10 }}
+      >
+        Close Modal with Data
+      </Button>
+
       <EditableInfoCard
         label="Title"
         value={title}

--- a/packages/design-system/OPENDRAWER.md
+++ b/packages/design-system/OPENDRAWER.md
@@ -1,215 +1,140 @@
-# Bottom Sheet/Drawer System in Design System
+# OpenDrawer Performance Optimization
 
-## Architecture Overview
+## The Issue
 
-The Design System implements a modal and drawer system using bottom sheets. Key files and components:
+When using `openDrawer` from the `useModal` hook, modal content components were being recreated on every parent component re-render. This caused significant performance issues and unexpected behavior.
 
-### Provider Hierarchy
+### The Problem
 
-1. **UIProvider** (`src/providers/UIProvider.tsx`)
-
-   - Root provider that sets up themes, languages, and core functionality
-   - Contains SafeAreaProvider, LanguageProvider, and GestureHandlerRootView
-   - Creates the portal system for rendering modals and drawers
-
-2. **ModalControllerProvider** (`src/providers/ModalControllerProvider.tsx`)
-
-   - Unified controller for both modals and bottom sheets (drawers)
-   - Provides a common interface through the `useModalController` hook
-   - Maintains shared ID counter for ordering modals/drawers
-
-3. **BottomSheetProvider** (`src/providers/BottomSheetProvider.tsx`)
-   - Implements the bottom sheet functionality
-   - Uses `BottomSheetModalProvider` from @gorhom/bottom-sheet
-   - Renders bottom sheets through a Portal
-
-### Core Hooks and Components
-
-1. **useBottomSheetStack** (`src/hooks/useBottomSheetStack.ts`)
-
-   - Manages the state of all bottom sheets/drawers
-   - Tracks opening, closing, and updates to bottom sheets
-   - Handles animations and presentation timing
-
-2. **BottomSheetModalWrapper** (`src/components/bottom-modal/BottomSheetModalWrapper.tsx`)
-
-   - Renders the actual bottom sheet UI components
-   - Configures keyboard behavior, animations, and appearance
-   - Contains handlers for user interaction
-
-3. **useModal** (`src/hooks/useModal/useModal.tsx`)
-   - Provides a clean API for opening drawers and modals
-   - Includes specialized functions like `editProp` for common scenarios
-   - Sets default configurations for different use cases
-
-## Design Goals
-
-### Drawer Hierarchy and Stacking
-
-A primary design goal was to support hierarchical drawer stacking, allowing multiple drawers to be opened on top of each other. This enables complex user flows such as:
-
-1. Opening a main drawer with a list of items
-2. Opening a second drawer to edit a selected item
-3. Opening a third drawer for a specific field's complex editor
-4. And so on...
-
-The system is designed so these drawers can be controlled independently:
-
-- Each drawer has its own state and lifecycle
-- Closing one drawer should not affect others (unless configured to do so)
-- Data can flow between drawers through the state system
-
-### State Management and Rendering Optimization
-
-The design aims to optimize rendering performance by:
-
-- Separating state from UI components
-- Using memoization to prevent unnecessary re-renders
-- Supporting partial updates to drawer content
-
-In theory, when a drawer's content changes (e.g., when typing in an input field), only the affected components should re-render, not the entire drawer or drawer stack. The state management is implemented with this optimization in mind:
-
-```typescript
-// Updating just one field in the drawer state
-onChange({ ...data, name: newName });
-```
-
-## Current Implementation
-
-### Opening a Drawer
-
-The primary way to open a drawer is through the `openDrawer` method provided by `useModal`:
-
-```typescript
+```tsx
+// In a parent component
 const { openDrawer } = useModal();
 
-const openMyDrawer = async () => {
+const handleOpenModal = async () => {
   const result = await openDrawer({
-    title: "My Drawer Title",
-    initialData: initialValues,
-    render: ({ state, onChange }) => {
-      // Render your drawer content here
-      return <YourComponent data={state.data} onChange={onChange} />;
-    },
-    bottomSheetProps: {
-      // Additional configuration for the bottom sheet
-    }
+    render: ({ resolve }) => (
+      // This component was being recreated on EVERY parent re-render!
+      <MyModalContent 
+        onFinish={(data) => resolve(data)}
+      />
+    ),
   });
+};
+```
 
-  // Handle the result when drawer closes
-  if (result) {
-    // Do something with the result
+Every time the parent component re-rendered (due to state changes, prop updates, etc.), the `render` function would be called again, creating a new instance of the modal content component. This caused:
+
+- **Hook Re-initialization**: All hooks (`useState`, `useEffect`, custom hooks) were re-initialized
+- **Lost Component State**: Any internal state was reset
+- **Performance Degradation**: Expensive operations were repeated unnecessarily
+- **Unexpected Side Effects**: Effects ran multiple times when they shouldn't
+
+### Common Scenarios Where This Occurred
+
+1. **Form Inputs**: Typing in any input field in the parent component
+2. **State Updates**: Any state change in the parent component
+3. **Context Updates**: Updates from context providers above the parent
+4. **Prop Changes**: New props passed to the parent component
+
+## The Solution
+
+We fixed this at the design-system level by ensuring modal content is only rendered once when the modal opens, not on every parent re-render.
+
+### Implementation
+
+The fix uses a combination of memoization and refs to maintain a stable reference to the rendered content:
+
+```tsx
+const ModalContent = memo(
+  ({ state, onChange, render, resolve, reject }: ModalContentProps) => {
+    // Store the initial render function in a ref to prevent re-creation
+    const renderRef = useRef(render);
+    
+    // Only update the ref on mount
+    useEffect(() => {
+      renderRef.current = render;
+    }, []); // Empty deps - only run once
+    
+    // Render using the stable reference
+    return (
+      <>
+        {renderRef.current({
+          state,
+          onChange,
+          resolve,
+          reject,
+        })}
+      </>
+    );
+  },
+  // Custom comparison to prevent unnecessary re-renders
+  (prevProps, nextProps) => {
+    return (
+      prevProps.modalId === nextProps.modalId &&
+      prevProps.state === nextProps.state &&
+      prevProps.onChange === nextProps.onChange &&
+      prevProps.resolve === nextProps.resolve &&
+      prevProps.reject === nextProps.reject
+    );
   }
-};
+);
 ```
 
-### Configuration Options
+## How It Works
 
-1. **Basic Properties**:
-
-   - `title`: Title displayed in the drawer header
-   - `initialData`: Initial data to populate the drawer
-   - `render`: Function to render drawer content
-   - `footerType`: Type of footer to show (e.g., 'confirm_cancel')
-
-2. **Bottom Sheet Properties**:
-   - `enableDynamicSizing`: Enables dynamic sizing based on content
-   - `snapPoints`: Array of snap points (e.g., ['50%'])
-   - `android_keyboardInputMode`: How Android handles keyboard ('adjustResize' or 'adjustPan')
-   - `keyboardBehavior`: How the sheet behaves when keyboard appears ('extend', 'interactive', etc.)
-
-## Current Issues
-
-### TextInput and Keyboard Handling
-
-When a TextInput component is placed inside a bottom sheet drawer and receives focus:
-
-1. The keyboard appears
-2. The TextInput is pushed off-screen or becomes obscured
-3. The user cannot see what they are typing
-
-### Current Configuration
-
-```typescript
-const defaultBottomSheetModalProps: Partial<BottomSheetModalProps> = {
-  enableDynamicSizing: true,
-  android_keyboardInputMode: "adjustResize",
-  keyboardBehavior: "extend",
-  keyboardBlurBehavior: "restore",
-  enablePanDownToClose: true,
-  enableDismissOnClose: true,
-  stackBehavior: "push",
-  backgroundStyle: { backgroundColor: "transparent" },
-  topInset: 50,
-};
+### Before the Fix
+```
+Parent Re-render → render() called → New Component Instance → All Hooks Re-initialized
 ```
 
-### Performance Issues
+### After the Fix
+```
+Parent Re-render → render() NOT called → Same Component Instance → Hooks Maintain State
+```
 
-Several performance issues have been observed in the current implementation:
+## API Compatibility
 
-1. **Input Field Responsiveness**:
+The `openDrawer` API remains completely unchanged. All existing functionality is preserved:
 
-   - Typing in text inputs sometimes feels sluggish
-   - The drawer may lag behind keyboard input
-   - This is especially noticeable when typing quickly
+```tsx
+const result = await openDrawer({
+  // Initial data for the modal
+  initialData: { name: '', email: '' },
+  
+  // Render the modal content
+  render: ({ state, onChange, resolve, reject }) => (
+    <MyModalContent
+      data={state.data}
+      onUpdate={(newData) => onChange(newData)}
+      onSave={(finalData) => resolve(finalData)}
+      onCancel={() => resolve(undefined)}
+      onError={(error) => reject(error)}
+    />
+  ),
+  
+  // Optional footer with access to current state
+  renderFooter: ({ state, resolve }) => (
+    <Button onPress={() => resolve(state.data)}>
+      Save Changes
+    </Button>
+  ),
+});
+```
 
-2. **Section Update Performance**:
+## Benefits
 
-   - When content in one section changes (e.g., main content), updates to other sections (header/footer) can be delayed
-   - State changes may not propagate efficiently across the drawer components
+1. **Improved Performance**: Modal content is rendered once per modal lifecycle
+2. **Predictable Behavior**: Hooks and effects work as expected without surprises
+3. **Better User Experience**: No flickering or state loss during interactions
+4. **Reduced Resource Usage**: Expensive operations aren't repeated unnecessarily
 
-3. **Rendering Optimization Concerns**:
+## Technical Details
 
-   - It's unclear if the current implementation properly optimizes rendering
-   - There may be unnecessary re-renders of the entire drawer when only small parts change
-   - The memoization strategy may need revision
+The optimization leverages:
 
-4. **Stacked Drawer Performance**:
-   - Multiple stacked drawers can compound performance issues
-   - State updates in lower drawers may inefficiently propagate through the stack
+- **React.memo**: Prevents re-renders when props haven't changed
+- **useRef**: Maintains stable references across renders
+- **Custom Comparison**: Fine-grained control over when re-renders occur
+- **Prop Stability**: Ensures callback functions maintain referential equality
 
-### Attempted Solutions
-
-1. Changed `keyboardBehavior` to various values ('extend', 'interactive')
-2. Used different `android_keyboardInputMode` settings ('adjustResize', 'adjustPan')
-3. Added dynamic sizing and proper snap points
-4. Tried manual keyboard height tracking
-
-### Needed Fixes
-
-#### Keyboard Handling Fix
-
-A solution is needed to properly handle keyboard appearance with TextInputs in bottom sheets, ensuring:
-
-1. The TextInput remains visible when keyboard appears
-2. The bottom sheet adjusts its position appropriately
-3. The user can see and interact with the input field
-
-Current evidence suggests the issue may be related to:
-
-- Snap point configuration
-- Keyboard behavior settings
-- Potential limitations in @gorhom/bottom-sheet itself
-- Interaction between SafeAreaView and keyboard handling
-
-#### Performance Optimization
-
-To address performance issues, several areas should be investigated:
-
-1. **Rendering Strategy**:
-
-   - Review the current memoization approach
-   - Ensure components are properly separated to prevent cascade re-renders
-   - Consider implementing `React.memo` more extensively
-
-2. **State Management**:
-
-   - Evaluate if the current state update mechanism is efficient
-   - Consider using a more optimized state management approach for complex forms
-   - Potentially implement useReducer with selective updates
-
-3. **Component Structure**:
-   - Separate header, content, and footer rendering more clearly
-   - Ensure state updates in one section don't trigger re-renders in others
-   - Consider using context selectors to optimize state consumption
+This ensures that modal content behaves like a properly isolated component, unaffected by parent component re-renders while still maintaining full reactivity to its own state changes.

--- a/packages/design-system/src/providers/BottomSheetProvider.tsx
+++ b/packages/design-system/src/providers/BottomSheetProvider.tsx
@@ -116,7 +116,14 @@ export const BottomSheetProvider = memo(
         </BottomSheetContext.Provider>
       );
     }
-  )
+  ),
+  (prevProps, nextProps) => {
+    return (
+      prevProps.children === nextProps.children &&
+      prevProps.defaultPortalName === nextProps.defaultPortalName &&
+      prevProps.sharedIdCounter === nextProps.sharedIdCounter
+    );
+  }
 );
 
 BottomSheetProvider.displayName = 'BottomSheetProvider';


### PR DESCRIPTION
# Description

## Purpose and Impact
Fixes a performance issue in `openDrawer` where modal content was recreated on every parent re-render, causing hook re-initializations, state loss, and lag. This change ensures modal content is rendered only once per lifecycle, improving performance, state stability, and user experience.

## Key Changes
- **ModalContent Memoization**: Used `React.memo` and `useRef` in `BottomSheetModalWrapper.tsx` to stabilize the `render` function, preventing re-renders unless `modalId`, `state`, `onChange`, `resolve`, or `reject` change.
- **BottomSheetProvider Optimization**: Added memoization to `BottomSheetProvider` to reduce unnecessary re-renders.
- **Debug Enhancements**: Updated `bug.tsx` with render tracking and state visualization to demonstrate the fix.
- **Dependency Cleanup**: Removed unneeded resolutions in `package.json`.
- **Documentation**: Rewrote `OPENDRAWER.md` to detail the issue, solution, and benefits.
